### PR TITLE
fix(attendance): replace skipPaging with paging parameter

### DIFF
--- a/src/hooks/attendance/useGetAttenceStatus.ts
+++ b/src/hooks/attendance/useGetAttenceStatus.ts
@@ -46,7 +46,7 @@ export const useGetAttenceStatus = ({ setattendanceHeaders, selectedDates, setAt
             filter: [...getFilters() as any, [`${academicYearId}:in:${academicYear}`]],
             ...selectedDates,
             orgUnit: orgUnit as unknown as any,
-            skipPaging: true
+            paging: false
         })
 
         if (attendanceMode === 'edit') {


### PR DESCRIPTION
The API parameter was incorrectly set to `skipPaging: true`. The correct parameter name is `paging: false` to disable pagination and retrieve all records.