### PR TITLE
feat: propagate baseUrl to enrollment buttons component

### DIFF
--- a/src/components/enrollmentButtons/EnrollmentActionsButtons.tsx
+++ b/src/components/enrollmentButtons/EnrollmentActionsButtons.tsx
@@ -8,15 +8,13 @@ import { getAttendanceDEHeaders } from '../../utils/common/getAttendanceDEHeader
 import { EnrollmentButtonsProps } from '../../types/enrollmentButons/enrollmentButtonsTypes';
 import { format, subDays } from "date-fns";
 import { generateattendanceHeaders } from '../../utils/header/generateAttendanceDays';
-import { useConfig } from '@dhis2/app-runtime';
 import { Tooltip } from '@mui/material';
 import { Event } from '@mui/icons-material';
 import useGetSelectedKeys from '../../hooks/config/useGetSelectedKeys';
 import { useSchoolCalendarKey } from 'dhis2-semis-components';
 
 function EnrollmentActionsButtons(props: EnrollmentButtonsProps) {
-    const { setRefetch, setIsTableReady, selectedDataStoreKey, setattendanceHeaders, setSelectedDates, i18n } = props
-    const { baseUrl } = useConfig()
+    const { setRefetch, setIsTableReady, selectedDataStoreKey, setattendanceHeaders, setSelectedDates, i18n, baseUrl } = props
     const { dataStoreData, program: programData } = useGetSelectedKeys()
     const { urlParameters, add } = useUrlParams();
     const { sectionName } = useGetSectionTypeLabel();

--- a/src/components/routes/Router.tsx
+++ b/src/components/routes/Router.tsx
@@ -11,7 +11,7 @@ export default function Router({ i18n, baseUrl }: { i18n: D2I18n; baseUrl: strin
             <Route path='/'
                 element={<WithHeaderBarLayout baseUrl={baseUrl} />}
             >
-                <Route key={'attendance'} path={'/'} element={<Attendance i18n={i18n} />} />
+                <Route key={'attendance'} path={'/'} element={<Attendance i18n={i18n} baseUrl={baseUrl} />} />
             </Route>
         </Routes>
     );

--- a/src/pages/attendance/attendance.tsx
+++ b/src/pages/attendance/attendance.tsx
@@ -18,7 +18,7 @@ import { classAttendanceEvent } from '../../schema/attendance/classAttendanceEve
 import { completenessLoading } from '../../schema/attendance/completenessLoading';
 import { allStudents } from '../../schema/students/allStudentList';
 
-export default function Attendance({ i18n }: { i18n: D2I18n }) {
+export default function Attendance({ i18n, baseUrl }: { i18n: D2I18n, baseUrl: string }) {
     const { program, dataStoreData } = useGetSelectedKeys()
     const { attendance = {} as unknown as any } = dataStoreData
     const { urlParameters } = useUrlParams(['position']);
@@ -128,6 +128,7 @@ export default function Attendance({ i18n }: { i18n: D2I18n }) {
                                     setSelectable={setSelectable}
                                     i18n={i18n}
                                     setRefetch={setRefetch}
+                                    baseUrl={baseUrl}
                                 />
                             }
                             beforeSettings={

--- a/src/types/enrollmentButons/enrollmentButtonsTypes.ts
+++ b/src/types/enrollmentButons/enrollmentButtonsTypes.ts
@@ -10,4 +10,5 @@ export interface EnrollmentButtonsProps {
     loading: boolean
     selectedDataStoreKey: selectedDataStoreKey
     i18n: D2I18n
+    baseUrl: string
 }


### PR DESCRIPTION
Remove dependency on useConfig hook by passing baseUrl explicitly through props. This ensures the component can function correctly even when useConfig is unavailable, improving reliability and testability.