### PR TITLE
fix: remove paging parameters to fix attendance data retrieval

### DIFF
--- a/src/hooks/attendance/useGetAttenceStatus.ts
+++ b/src/hooks/attendance/useGetAttenceStatus.ts
@@ -46,7 +46,6 @@ export const useGetAttenceStatus = ({ setattendanceHeaders, selectedDates, setAt
             filter: [...getFilters() as any, [`${academicYearId}:in:${academicYear}`]],
             ...selectedDates,
             orgUnit: orgUnit as unknown as any,
-            paging: false
         })
 
         if (attendanceMode === 'edit') {

--- a/src/pages/attendance/attendance.tsx
+++ b/src/pages/attendance/attendance.tsx
@@ -48,8 +48,6 @@ export default function Attendance({ i18n, baseUrl }: { i18n: D2I18n, baseUrl: s
     useEffect(() => {
         if (selectedDates?.occurredAfter && selectedDates?.occurredBefore && areAllSelected()) {
             void getData({
-                paging: false,
-                skipPaging: true,
                 program: program!?.id as string,
                 orgUnit: urlParameters?.school!,
                 baseProgramStage: dataStoreData?.registration?.programStage,


### PR DESCRIPTION
The paging and skipPaging parameters were incorrectly preventing full data retrieval in attendance hooks and pages. Removing these parameters ensures complete attendance records are fetched regardless of dataset size.